### PR TITLE
OcItemQuery implementation

### DIFF
--- a/app/Http/Controllers/OcItemQueryController.php
+++ b/app/Http/Controllers/OcItemQueryController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\OcItemQuery;
+use App\OrdenCompra;
+use App\OcState;
+use DateTime;
+use Facades\App\Util\MercadoPublico;
+use Validator;
+
+class OcItemQueryController extends Controller
+{
+    /**
+     * Display a listing of oc_item_queries.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return view('oc_item_queries.index')
+        	->with('title','Items de Órdenes de Compra')
+            ->with('oc_item_queries',
+            	OcItemQuery::query()
+            		->orderBy('query_date','desc')
+            		->limit(100)
+            		->get());
+    }
+
+    /**
+     * Suggests OrdenCompra codes
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function suggest(Request $request)
+    {
+        $validation_rules = ['partial'=> 'required|string|max:500'];
+        $validator = Validator::make($request->all(), $validation_rules);
+
+        if ($validator->fails()) {
+            return response()->json(OrdenCompra::query()
+                    ->limit(5)
+                    ->get()
+                    ->map(function($oc){return $oc->code;}));
+        }
+        return response()->json(OrdenCompra::query()
+                ->where('code','like','%'.$request->request->get('partial').'%')
+                ->limit(5)
+                ->get()
+                ->map(function($oc){return $oc->code;}));
+    }
+
+    /**
+     * Stores a new oc_item_query (and corresponding CompraPublica)
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+    	/*$validation_rules = ['date'=> 'date|before_or_equal:today'];
+    	$validation_messages = [
+    		'date.date'=> ':attribute no es una fecha válida.',
+    		'date.before_or_equal' => ':attribute debe estar en el pasado.'];
+		$validator = Validator::make($request->all(), $validation_rules, $validation_messages);
+
+        if ($validator->fails()) {
+            return redirect('oc_list_queries')
+                        ->withErrors($validator)
+                        ->withInput();
+        }*/
+    	$ticket = '34EA724F-17C8-462E-B23B-4A92B3A2F622';
+    	//'F8537A18-6766-4DEF-9E59-426B4FEE2844'
+
+    	$code = $request->request->get('code');
+    	$req_url = 'http://api.mercadopublico.cl/servicios/v1/publico/';
+ 		$req_url .= 'ordenesdecompra.json';
+ 		$req_url .= '?codigo='.$code;
+ 		$req_url .= '&ticket='.$ticket;
+    	$result = MercadoPublico::get($req_url);
+    	$json = json_decode($result);
+
+        return redirect()
+        	->route('oc_item_queries')
+        	->with('success-message','Item de Órden de Compra con código '.
+									 $request->request->get('code').
+									 ' adicionado con éxito');
+    }
+
+}

--- a/app/Http/Controllers/OcListQueryController.php
+++ b/app/Http/Controllers/OcListQueryController.php
@@ -58,7 +58,7 @@ class OcListQueryController extends Controller
     	$json = json_decode($result);
 
     	if(property_exists($json, 'Codigo') and property_exists($json, 'Mensaje')) {
-    		return redirect()>route('oc_list_queries')
+    		return redirect('oc_list_queries')
 	        	->withErrors([$json->Codigo=> $json->Mensaje]);
     	}
 
@@ -67,7 +67,7 @@ class OcListQueryController extends Controller
     	$oc_states = OcState::all();
 
     	if(!property_exists($json, 'Listado')){
-    		return redirect()>route('oc_list_queries')
+    		return redirect('oc_list_queries')
 	        	->withErrors(['empty'=> 'Lista vacia o error encontrado']);
     	}
 

--- a/app/Http/Controllers/OcListQueryController.php
+++ b/app/Http/Controllers/OcListQueryController.php
@@ -21,7 +21,11 @@ class OcListQueryController extends Controller
     {
         return view('oc_list_queries.index')
         	->with('title','Lista de Órdenes de Compra')
-            ->with('oc_list_queries',OcListQuery::withCount('orden_compras')->get());
+            ->with('oc_list_queries',
+            	OcListQuery::withCount('orden_compras')
+            		->orderBy('date','desc')
+            		->limit(20)
+            		->get());
     }
 
     /**

--- a/app/Http/Controllers/OcListQueryController.php
+++ b/app/Http/Controllers/OcListQueryController.php
@@ -76,9 +76,8 @@ class OcListQueryController extends Controller
     		return ['code'=>$item->CodigoEstado,'name'=>$item->CodigoEstado]; });
     	foreach($all_oc->unique() as $oc) {
     		if($oc_states->where('code',$oc['code'])->where('name',$oc['name'])->count()==0) {
-    			OcState::firstOrCreate([
-    				'code' => $oc['code'], 
-    				'name' => $oc['name']]);
+    			OcState::firstOrCreate(['code' => $oc['code']],
+                    ['name' => $oc['name']]);
     			$oc_states = OcState::all();
     		}
     	}

--- a/app/Http/Controllers/OcListQueryController.php
+++ b/app/Http/Controllers/OcListQueryController.php
@@ -75,7 +75,7 @@ class OcListQueryController extends Controller
     	$all_oc = $all_oc->map(function($item, $key){ 
     		return ['code'=>$item->CodigoEstado,'name'=>$item->CodigoEstado]; });
     	foreach($all_oc->unique() as $oc) {
-    		if($oc_states->where('code',$oc['code'])->where('name',$oc['name'])->count()==0) {
+    		if($oc_states->where('code',$oc['code'])->count()==0) {
     			OcState::firstOrCreate(['code' => $oc['code']],
                     ['name' => $oc['name']]);
     			$oc_states = OcState::all();
@@ -90,7 +90,6 @@ class OcListQueryController extends Controller
     		$oc_attr[] = [
     			'name' => $oc->Nombre,
     			'oc_state_id' => $oc_states->where('code',$oc->CodigoEstado)
-    				->where('name',$oc->CodigoEstado)
     				->first()
     				->id];
     	}

--- a/app/OcDeliveryType.php
+++ b/app/OcDeliveryType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OcDeliveryType extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['code', 'name'];
+
+    /**
+     * Get the OcItemQueries that belong to this delivery_type.
+     */
+    public function oc_item_queries()
+    {
+        return $this->hasMany('App\OcItemQuery');
+    }
+}

--- a/app/OcItemQuery.php
+++ b/app/OcItemQuery.php
@@ -7,4 +7,46 @@ use Illuminate\Database\Eloquent\Model;
 class OcItemQuery extends Model
 {
     public $timestamps = false;
+    //protected $fillable = ['query_date'];
+    protected $dates = ['query_date','created_at','sent_at','accepted_at','cancelled_at','updated_at'];
+
+    /**
+     * Get the OrdenCompra associated with the OcItemQuery.
+     */
+    public function orden_compra()
+    {
+        return $this->belongsTo('App\OrdenCompra');
+    }
+
+    /**
+     * Get the state associated with the OcItemQuery.
+     */
+    public function oc_state()
+    {
+        return $this->belongsTo('App\OcState');
+    }
+
+    /**
+     * Get the type associated with the OcItemQuery.
+     */
+    public function oc_type()
+    {
+        return $this->belongsTo('App\OcType');
+    }
+
+    /**
+     * Get the delivery_type associated with the OcItemQuery.
+     */
+    public function oc_delivery_type()
+    {
+        return $this->belongsTo('App\OcDeliveryType');
+    }
+
+    /**
+     * Get the payment_type associated with the OcItemQuery.
+     */
+    public function oc_payment_type()
+    {
+        return $this->belongsTo('App\OcPaymentType');
+    }
 }

--- a/app/OcItemQuery.php
+++ b/app/OcItemQuery.php
@@ -7,7 +7,25 @@ use Illuminate\Database\Eloquent\Model;
 class OcItemQuery extends Model
 {
     public $timestamps = false;
-    //protected $fillable = ['query_date'];
+    protected $fillable = [
+            'query_date',
+            'orden_compra_id',
+            'name',
+            'oc_state_id',
+            'description',
+            'oc_type_id',
+            'created_at',
+            'sent_at',
+            'accepted_at',
+            'cancelled_at',
+            'updated_at',
+            'classification_mean',
+            'classification_n',
+            'financing',
+            'country',
+            'oc_delivery_type_id',
+            'oc_payment_type_id'
+    ];
     protected $dates = ['query_date','created_at','sent_at','accepted_at','cancelled_at','updated_at'];
 
     /**

--- a/app/OcListQueryOrdenCompra.php
+++ b/app/OcListQueryOrdenCompra.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class OcListQueryOrdenCompra extends Pivot
 {
+    public $timestamps = false;
+    //protected $fillable = ['name','oc_state_id'];
+
     /**
      * Get the state associated with the OcListQuery & OrdenCompra.
      */

--- a/app/OcPaymentType.php
+++ b/app/OcPaymentType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OcPaymentType extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['code', 'name'];
+
+    /**
+     * Get the OcItemQueries that belong to this payment_type.
+     */
+    public function oc_item_queries()
+    {
+        return $this->hasMany('App\OcItemQuery');
+    }
+}

--- a/app/OcState.php
+++ b/app/OcState.php
@@ -16,4 +16,12 @@ class OcState extends Model
     {
         return $this->hasMany('App\OcListQueryOrdenCompra');
     }
+
+    /**
+     * Get the OcItemQueries that belong to this state.
+     */
+    public function oc_item_queries()
+    {
+        return $this->hasMany('App\OcItemQuery');
+    }
 }

--- a/app/OcType.php
+++ b/app/OcType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OcType extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['code', 'name'];
+
+    /**
+     * Get the OcItemQueries that belong to this type.
+     */
+    public function oc_item_queries()
+    {
+        return $this->hasMany('App\OcItemQuery');
+    }
+}

--- a/app/OrdenCompra.php
+++ b/app/OrdenCompra.php
@@ -10,14 +10,22 @@ class OrdenCompra extends Model
     protected $fillable = ['code'];
 
     /**
-     * The OcListQuery's that contain the OrdenCompra
+     * The OcListQueries that contain the OrdenCompra
      */
     public function oc_list_queries()
     {
         return $this->belongsToMany('App\OcListQuery')
             ->withPivot('name')
             ->withPivot('oc_state_id')
-        	->using('App\OcListQueryOrdenCompra');
+            ->using('App\OcListQueryOrdenCompra');
+    }
+
+    /**
+     * The OcItemQueries that contain the OrdenCompra
+     */
+    public function oc_item_queries()
+    {
+        return $this->hasMany('App\OcItemQuery');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.0.0",
+        "doctrine/dbal": "^2.5",
         "fideloper/proxy": "~3.3",
         "laravel/framework": "5.5.*",
         "laravel/tinker": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f89c020c0beb2a8ab6e163a39fd1b19",
+    "content-hash": "070509c3b21bf117758359f31fa93ff8",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -38,6 +38,355 @@
             ],
             "description": "implementation of xdg base directory specification for php",
             "time": "2014-10-24T07:27:01+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-02-24T16:22:25+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-07-22T12:49:21+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-01-03T10:49:41+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "reference": "4acb8f89626baafede6ee5475bc5844096eba8a9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~5.6|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-07-22T08:35:12+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.5.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "729340d8d1eec8f01bff708e12e449a3415af873"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/729340d8d1eec8f01bff708e12e449a3415af873",
+                "reference": "729340d8d1eec8f01bff708e12e449a3415af873",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.4,<2.8-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*||^3.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2017-07-22T20:44:48+00:00"
         },
         {
             "name": "doctrine/inflector",

--- a/database/migrations/2018_01_05_203649_improves_oc_item_query.php
+++ b/database/migrations/2018_01_05_203649_improves_oc_item_query.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ImprovesOcItemQuery extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('oc_item_querys','oc_item_queries');
+
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->string('name', 500)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->string('name', 200)->change();
+        });
+
+        Schema::rename('oc_item_queries','oc_item_querys');
+    }
+}

--- a/database/migrations/2018_01_05_204436_orden_compra_code_unique.php
+++ b/database/migrations/2018_01_05_204436_orden_compra_code_unique.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\OrdenCompra;
+use App\OcListQueryOrdenCompra;
+
+class OrdenCompraCodeUnique extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // remove repeated codes in OrdenCompra
+        foreach(OrdenCompra::query()->select('code')->groupBy('code')->havingRaw('count(code) > 1')->get() as $oc) {
+            $surviving_oc = OrdenCompra::where('code',$oc->code)->first();
+            foreach(OrdenCompra::where([
+                ['code',$surviving_oc->code],
+                ['id','<>',$surviving_oc->id]])->get() as $repeated_oc) {
+                    foreach($repeated_oc->oc_list_queries as $oc_list_query){
+                        $oc_list_query->orden_compras()->attach($surviving_oc->id,
+                            ['name'=> $oc_list_query->pivot->name,
+                             'oc_state_id'=> $oc_list_query->pivot->oc_state_id]);
+                    }
+                    $repeated_oc->oc_list_queries()->detach();
+                    $repeated_oc->delete();
+                }
+        }
+        Schema::table('orden_compras', function (Blueprint $table) {
+            $table->unique('code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('orden_compras', function (Blueprint $table) {
+            $table->dropUnique('orden_compras_code_unique');
+        });
+    }
+}

--- a/database/migrations/2018_01_07_181642_oc_item_query_dates_nullable.php
+++ b/database/migrations/2018_01_07_181642_oc_item_query_dates_nullable.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class OcItemQueryDatesNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->dateTime('created_at')->nullable()->change();
+            $table->dateTime('sent_at')->nullable()->change();
+            $table->dateTime('accepted_at')->nullable()->change();
+            $table->dateTime('cancelled_at')->nullable()->change();
+            $table->dateTime('updated_at')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->dateTime('created_at')->nullable(false)->change();
+            $table->dateTime('sent_at')->nullable(false)->change();
+            $table->dateTime('accepted_at')->nullable(false)->change();
+            $table->dateTime('cancelled_at')->nullable(false)->change();
+            $table->dateTime('updated_at')->nullable(false)->change();
+        });
+    }
+}

--- a/database/migrations/2018_01_07_183022_oc_item_query_increase_description_size.php
+++ b/database/migrations/2018_01_07_183022_oc_item_query_increase_description_size.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\OcItemQuery;
+
+class OcItemQueryIncreaseDescriptionSize extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->renameColumn('description','description_old');
+        });
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->text('description');
+        });
+        foreach(OcItemQuery::all() as $oc_item){
+            $oc_item->description = $oc_item->description_old;
+            $oc_item->save();
+        }
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->dropColumn('description_old');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->renameColumn('description','description_old');
+        });
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->string('description',500);
+        });
+        foreach(OcItemQuery::all() as $oc_item){
+            $oc_item->description = $oc_item->description_old;
+            $oc_item->save();
+        }
+        Schema::table('oc_item_queries', function (Blueprint $table) {
+            $table->dropColumn('description_old');
+        });
+    }
+}

--- a/database/migrations/2018_01_07_184808_oc_state_increase_name.php
+++ b/database/migrations/2018_01_07_184808_oc_state_increase_name.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class OcStateIncreaseName extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oc_states', function (Blueprint $table) {
+            $table->string('name',50)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oc_states', function (Blueprint $table) {
+            $table->string('name',10)->change();
+        });
+    }
+}

--- a/database/migrations/2018_01_07_190435_add_oc_list_query_orden_compra_primary.php
+++ b/database/migrations/2018_01_07_190435_add_oc_list_query_orden_compra_primary.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\OcState;
+use App\OcType;
+use App\OcDeliveryType;
+use App\OcPaymentType;
+
+class AddOcListQueryOrdenCompraPrimary extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oc_list_query_orden_compra', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unique(['oc_list_query_id', 'orden_compra_id'],
+                'oc_list_query_id_orden_compra_id_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oc_list_query_orden_compra', function (Blueprint $table) {
+            $table->dropColumn('id');
+            $table->dropUnique('oc_list_query_id_orden_compra_id_unique');
+        });
+    }
+}

--- a/database/migrations/2018_01_07_204356_add_known_state_type_delivery_payment.php
+++ b/database/migrations/2018_01_07_204356_add_known_state_type_delivery_payment.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\OcState;
+use App\OcType;
+use App\OcDeliveryType;
+use App\OcPaymentType;
+
+class AddKnownStateTypeDeliveryPayment extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $oc_states = [
+            ['code'=> '4','name'=> 'Enviada a Proveedor'],
+            ['code'=> '6','name'=> 'Aceptada'],
+            ['code'=> '9','name'=> 'Cancelada'],
+            ['code'=> '12','name'=> 'Recepción Conforme'],
+            ['code'=> '13','name'=> 'Pendiente de Recepcionar'],
+            ['code'=> '14','name'=> 'Recepcionada Parcialmente'],
+            ['code'=> '15','name'=> 'Recepcion Conforme Incompleta']
+        ];
+        foreach($oc_states as $oc_state){
+            $new = OcState::firstOrCreate($oc_state);
+            foreach(OcState::where('code',$new->code)
+                ->where('name','<>',$new->name)
+                ->get() as $old) {
+                    foreach($old->oc_item_queries as $oc_item) {
+                        $oc_item->oc_state()->associate($new);
+                        $oc_item->save();
+                    }
+                    foreach($old->oc_list_query_orden_compras as $oc_list_oc) {
+                        $oc_list_oc->oc_state()->associate($new);
+                        $oc_list_oc->save();
+                    }
+                    $old->delete();
+            }
+        }
+
+        $oc_types = [
+            ['code'=> 'OC', 'name'=> 'Automatica'],
+            ['code'=> 'D1', 'name'=> 'Trato directo que genera Orden de Compra por proveedor único'],
+            ['code'=> 'C1', 'name'=> 'Trato directo que genera Orden de Compra por emergencia, urgencia e imprevisto'],
+            ['code'=> 'F3', 'name'=> 'Trato directo que genera Orden de Compra por confidencialidad'],
+            ['code'=> 'G1', 'name'=> 'Trato directo que genera Orden de Compra por naturaleza de negociación'],
+            ['code'=> 'R1', 'name'=> 'Orden de compra menor a 3UTM'],
+            ['code'=> 'CA', 'name'=> 'Orden de compra sin resolución.'],
+            ['code'=> 'SE', 'name'=> 'Sin emisión automática'],
+            ['code'=> 'CM', 'name'=> 'Convenio Marco'],
+            ['code'=> 'FG', 'name'=> 'FG'],
+            ['code'=> 'TL', 'name'=> 'TL']
+        ];
+
+        Schema::table('oc_types', function (Blueprint $table) {
+            $table->string('name',100)->change();
+        });
+        foreach($oc_types as $oc_type){
+            $new = OcType::firstOrCreate($oc_type);
+            foreach(OcType::where('code',$new->code)
+                ->where('name','<>',$new->name)
+                ->get() as $old) {
+                    foreach($old->oc_item_queries as $oc_item) {
+                        $oc_item->oc_type()->associate($new);
+                        $oc_item->save();
+                    }
+                    $old->delete();
+            }
+        }
+
+        $oc_delivery_types = [
+            ['code'=>7, 'name'=> 'Despachar a Dirección de envío'],
+            ['code'=>9, 'name'=> 'Despachar según programa adjuntado'],
+            ['code'=>12, 'name'=> 'Otra Forma de Despacho, Ver Instruc'],
+            ['code'=>14, 'name'=> 'Retiramos de su bodega'],
+            ['code'=>20, 'name'=> 'Despacho por courier o encomienda aérea'],
+            ['code'=>21, 'name'=> 'Despacho por courier o encomienda terrestre'],
+            ['code'=>22, 'name'=> 'A convenir']
+        ];
+        foreach($oc_delivery_types as $oc_delivery_type){
+            $new = OcDeliveryType::firstOrCreate($oc_delivery_type);
+            foreach(OcDeliveryType::where('code',$new->code)
+                ->where('name','<>',$new->name)
+                ->get() as $old) {
+                    foreach($old->oc_item_queries as $oc_item) {
+                        $oc_item->oc_delivery_type()->associate($new);
+                        $oc_item->save();
+                    }
+                    $old->delete();
+            }
+        }
+
+        $oc_payment_types = [
+            ['code'=>1, 'name'=> '15 días contra la recepción de la factura'],
+            ['code'=>2, 'name'=> '30 días contra la recepción de la factura'],
+            ['code'=>39, 'name'=> 'Otra forma de pago'],
+            ['code'=>46, 'name'=> '50 días contra la recepción de la factura'],
+            ['code'=>47, 'name'=> '60 días contra la recepción de la factura'],
+        ];
+        foreach($oc_payment_types as $oc_payment_type){
+            $new = OcPaymentType::firstOrCreate($oc_payment_type);
+            foreach(OcPaymentType::where('code',$new->code)
+                ->where('name','<>',$new->name)
+                ->get() as $old) {
+                    foreach($old->oc_item_queries as $oc_item) {
+                        $oc_item->oc_payment_type()->associate($new);
+                        $oc_item->save();
+                    }
+                    $old->delete();
+            }
+        }
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        foreach(OcTypes::whereRaw('CHAR_LENGTH(code) > 50') as $oc_type) {
+            $oc_type->oc_item_queries()->detach();
+            $oc_type->delete();
+        }
+
+        Schema::table('oc_types', function (Blueprint $table) {
+            $table->string('name',50)->change();
+        });
+    }
+}

--- a/resources/views/oc_item_queries/index.blade.php
+++ b/resources/views/oc_item_queries/index.blade.php
@@ -1,0 +1,90 @@
+@extends('layouts.base')
+
+@section('main')
+<div class="card bg-light mb-3">
+	<h4 class='card-header'> Adicionar Item de una Órden de Compra</h2>
+	<div class="card-body">
+		{!! Form::open(['url' => 'oc_item_queries']) !!}
+		{!! Form::label('code', 'Código: ') !!}
+		{!! Form::text('code',null,['id' => 'codepicker']) !!}
+		{!! Form::submit('Adicionar',['class'=> 'btn btn-primary']) !!}
+		{!! Form::close() !!}
+	</div>
+</div>
+<script>
+$( "#codepicker" ).autocomplete({
+  source: function( request, response ) {
+    $.post( {
+      url: "{{route('oc_item_suggest')}}",
+      data: {'partial': request.term, '_token': "{{csrf_token()}}"},
+      success: function( data ) {
+        response( data );
+      }
+    } );
+  },
+  select: function( event, ui ) {
+    console.log( "Selected: " + ui.item.value + " aka " + ui.item.id );
+  }
+});
+</script>
+
+<div class="container">
+<h4 class="text-dark">Items de Órdenes de Compra</h4>
+@foreach($oc_item_queries->chunk(3) as $chunk)
+	<div class='card-deck'>
+	@foreach($chunk as $item)
+		<div class="card border-info mb-3">
+			<div class="card-body">
+				<h5 class="card-title text-dark">{{ $item->code }}: <span class="text-info">{{$item->name}}</span> </h5>
+				<p><small class="text-muted">(obtenida {{$item->query_date}})</small></p>
+				<div class="card-block pre-scrollable list-group" >
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Descripción</span>: </h6>
+				    	<div>{{$item->description}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Financiamiento</span>: </h6>
+				    	<div>{{$item->financing}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Pais</span>: </h6>
+				    	<div>{{$item->country}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Clasificaciones</span>: </h6>
+				    	<div>Promedio: {{$item->classification_mean}}</div>
+				    	<div>Número: {{$item->classification_n}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Estado</span>: </h6>
+				    	<div>{{$item->oc_state->name}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Tipo</span>: </h6>
+				    	<div>{{$item->oc_type->name}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Forma de Entrega</span>: </h6>
+				    	<div>{{$item->delivery_type->name}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Forma de Pago</span>: </h6>
+				    	<div>{{$item->payment_type->name}}</div>
+				    </button>
+				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
+				    	<h6><span class="font-weight-bold">Fechas</span>: </h6>
+				    	<div>Creada: {{$item->created_at}}</div>
+				    	<div>Enviada: {{$item->sent_at}}</div>
+				    	<div>Aceptada: {{$item->accepted_at}}</div>
+				    	<div>Cancelada: {{$item->cancelled_at}}</div>
+				    	<div>Última Actualización: {{$item->updated_at}}</div>
+				    </button>
+				</div>	
+			</div>
+		</div>
+	@endforeach
+	</div>
+@endforeach
+</div>
+
+@endsection

--- a/resources/views/oc_item_queries/index.blade.php
+++ b/resources/views/oc_item_queries/index.blade.php
@@ -35,7 +35,7 @@ $( "#codepicker" ).autocomplete({
 	@foreach($chunk as $item)
 		<div class="card border-info mb-3">
 			<div class="card-body">
-				<h5 class="card-title text-dark">{{ $item->code }}: <span class="text-info">{{$item->name}}</span> </h5>
+				<h5 class="card-title text-dark">{{ $item->orden_compra->code }}: <span class="text-info">{{$item->name}}</span> </h5>
 				<p><small class="text-muted">(obtenida {{$item->query_date}})</small></p>
 				<div class="card-block pre-scrollable list-group" >
 				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
@@ -65,11 +65,11 @@ $( "#codepicker" ).autocomplete({
 				    </button>
 				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
 				    	<h6><span class="font-weight-bold">Forma de Entrega</span>: </h6>
-				    	<div>{{$item->delivery_type->name}}</div>
+				    	<div>{{$item->oc_delivery_type->name}}</div>
 				    </button>
 				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
 				    	<h6><span class="font-weight-bold">Forma de Pago</span>: </h6>
-				    	<div>{{$item->payment_type->name}}</div>
+				    	<div>{{$item->oc_payment_type->name}}</div>
 				    </button>
 				    <button type="button" class="list-group-item list-group-item-secondary list-group-item-action">
 				    	<h6><span class="font-weight-bold">Fechas</span>: </h6>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ Route::get('/oc_list_queries', 'OcListQueryController@index')->name('oc_list_que
 Route::post('/oc_list_queries','OcListQueryController@store');
 Route::get('/oc_item_queries', 'OcItemQueryController@index')->name('oc_item_queries');
 Route::post('/oc_item_queries','OcItemQueryController@store');
+Route::post('/oc_item_queries/suggest','OcItemQueryController@suggest')->name('oc_item_suggest');
 
 Route::resource('ocs', 'OrdenCompraController');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,8 @@ Route::get('/', function () {
 
 Route::get('/oc_list_queries', 'OcListQueryController@index')->name('oc_list_queries');
 Route::post('/oc_list_queries','OcListQueryController@store');
+Route::get('/oc_item_queries', 'OcItemQueryController@index')->name('oc_item_queries');
+Route::post('/oc_item_queries','OcItemQueryController@store');
 
 Route::resource('ocs', 'OrdenCompraController');
 

--- a/tests/Feature/OcListQueryTest.php
+++ b/tests/Feature/OcListQueryTest.php
@@ -25,11 +25,11 @@ class OcListQueryTest extends TestCase
         MercadoPublico::shouldReceive('get')->andReturn($sample);
 
         $time_start = microtime(true);
-        $response = $this->followingRedirects()->post('/oc_list_queries',['date'=>'01/01/2017']);
+        $response = $this->followingRedirects()->post('/oc_list_queries',['date'=>'01-01-2017']);
         $time_end = microtime(true);
 
         $response->assertSuccessful();
-        $response->assertSee('01/01/2017');
+        $response->assertSee('01-01-2017');
         $response->assertSee(strval($json->Cantidad));
         $this->assertLessThan(15, $time_end-$time_start);
 


### PR DESCRIPTION
- Implements OcItemQuery, OcType, OcDeliveryType, OcPaymentType models and tables.
- General fixes for models properties (mostly name) and relations (especially in OcListQueryOrdenCompra).
- Implements OcItemQuery index page in a similar fashion as OcListQuery's.
- Adds autocomplete suggestion for adding OcItemQueries.
- Adds known values to OcState, OcType, OcDeliveryType and OcPayment, according to [MercadoPublico API docs](https://api.mercadopublico.cl/modules/api.aspx), and removes repeated ones.